### PR TITLE
[BUILD] Improve REUSE workflow

### DIFF
--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -10,6 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout Repository
+      uses: actions/checkout@v4
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@v4

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -9,8 +9,10 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-22.04
+
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
+      
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@v4

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -15,4 +15,4 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       
     - name: REUSE Compliance Check
-      uses: fsfe/reuse-action@3ae3c6bdf1257ab19397fab11fd3312144692083 # v4.0.0
+      uses: fsfe/reuse-action@bb774aa972c2a89ff34781233d275075cbddf542 # v5.0.0

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -15,4 +15,4 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       
     - name: REUSE Compliance Check
-      uses: fsfe/reuse-action@v4
+      uses: fsfe/reuse-action@3ae3c6bdf1257ab19397fab11fd3312144692083 # v4.0.0

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@v4

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -8,7 +8,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4


### PR DESCRIPTION
This `PR` improves the `REUSE` workflow, which importantly includes to switch to hashes for pinning the actions to increase security, and also bumps the `reuse-action` from `4.0.0` to `5.0.0`.

The other changes are (i) adding names to steps, (ii) and adding blank lines to improve readability.