### PR TITLE
[DOC] Improve License Section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Copyright (c) XXXX Deutsche Telekom AG
 Licensed under the XXXX (SPDX short identifier: XXXX) (the "License"); you may not use this file except in compliance with the License. 
 You may obtain a copy of the License by reviewing the files found in the [./LICENSES](./LICENSES) folder.
 
+Unless required by applicable law or agreed to in writing, software distributed under the Licenses is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See in the [./LICENSES](./LICENSES) folder for the specific language governing permissions and limitations under the Licenses.
+
 This project follows the [REUSE standard for software licensing](https://reuse.software/). 
 Each file contains copyright and license information, and license texts can be found in the [./LICENSES](./LICENSES) folder. For more information visit https://reuse.software/.
 You can find a guide for developers at https://telekom.github.io/reuse-template/.

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ By participating in this project, you agree to abide by its [Code of Conduct](./
 ## Licensing
 Copyright (c) XXXX Deutsche Telekom AG
 
-Licensed under the XXXX (SPDX short identifier: XXXX) (the "License"); you may not use this file except in compliance with the License. 
-You may obtain a copy of the License by reviewing the files found in the [./LICENSES](./LICENSES) folder.
+Licensed under the XXXX (SPDX short identifier: xxxx), YYYY (SPDX short identifier: yyyy) (the "Licenses"); you may not use this file except in compliance with the Licenses. 
+You may obtain a copy of the Licenses by reviewing the files found in the [./LICENSES](./LICENSES) folder.
 
 Unless required by applicable law or agreed to in writing, software distributed under the Licenses is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See in the [./LICENSES](./LICENSES) folder for the specific language governing permissions and limitations under the Licenses.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ By participating in this project, you agree to abide by its [Code of Conduct](./
 ## Licensing
 Copyright (c) XXXX Deutsche Telekom AG
 
+Licensed under the XXXX (SPDX short identifier: XXXX) (the "License"); you may not use this file except in compliance with the License. 
+You may obtain a copy of the License by reviewing the files found in the [./LICENSES](./LICENSES) folder.
+
 This project follows the [REUSE standard for software licensing](https://reuse.software/). 
 Each file contains copyright and license information, and license texts can be found in the [./LICENSES](./LICENSES) folder. For more information visit https://reuse.software/.
 You can find a guide for developers at https://telekom.github.io/reuse-template/.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ By participating in this project, you agree to abide by its [Code of Conduct](./
 ## Licensing
 Copyright (c) XXXX Deutsche Telekom AG
 
-Licensed under the XXXX (SPDX short identifier: xxxx), YYYY (SPDX short identifier: yyyy) (the "Licenses"); you may not use this file except in compliance with the Licenses. 
+All content in this repository is licensed under at least one of the licenses found in [./LICENSES](./LICENSES); you may not use this file, or any other file in this repository, except in compliance with the Licenses. 
 You may obtain a copy of the Licenses by reviewing the files found in the [./LICENSES](./LICENSES) folder.
 
 Unless required by applicable law or agreed to in writing, software distributed under the Licenses is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See in the [./LICENSES](./LICENSES) folder for the specific language governing permissions and limitations under the Licenses.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ By participating in this project, you agree to abide by its [Code of Conduct](./
 
 ## Licensing
 
-This project follows the [REUSE standard for software licensing](https://reuse.software/).    
-Each file contains copyright and license information, and license texts can be found in the [./LICENSES](./LICENSES) folder. For more information visit https://reuse.software/.    
-You can find a guide for developers at https://telekom.github.io/reuse-template/.   
+This project follows the [REUSE standard for software licensing](https://reuse.software/). 
+Each file contains copyright and license information, and license texts can be found in the [./LICENSES](./LICENSES) folder. For more information visit https://reuse.software/.
+You can find a guide for developers at https://telekom.github.io/reuse-template/.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This project has adopted the [Contributor Covenant](https://www.contributor-cove
 By participating in this project, you agree to abide by its [Code of Conduct](./CODE_OF_CONDUCT.md) at all times.
 
 ## Licensing
+Copyright (c) XXXX Deutsche Telekom AG
 
 This project follows the [REUSE standard for software licensing](https://reuse.software/). 
 Each file contains copyright and license information, and license texts can be found in the [./LICENSES](./LICENSES) folder. For more information visit https://reuse.software/.


### PR DESCRIPTION
This `PR` improves the license section in the `README` by adding a **copyright**, **license**, and **warranty disclaimer** paragraph. On a minor note, the `PR` also deletes characters that insereted line breaks at the end of each sentence in the `REUSE` paragraph.

This `PR` is part of the *effort* to make the template more of an *open source* template, instead of it being purely a `REUSE` template.