### PR TITLE
[BUILD] Add restriction for GitHub token in REUSE workflow

### DIFF
--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -6,6 +6,11 @@ name: REUSE Compliance Check
 
 on: [push, pull_request]
 
+
+permissions:
+  contents: read
+
+
 jobs:
   test:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This `PR` sets the permission for `contents` to `read` to improve the security of the `REUSE` workflow.